### PR TITLE
Fix include bug on MacOS by concatenating config files to final one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /output
-openssl.cnf
+openssl.base.cnf
 openssl.dns.cnf

--- a/openssl.base.default.cnf
+++ b/openssl.base.default.cnf
@@ -365,4 +365,3 @@ ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 
 ####################################################################
 
-.include openssl.dns.cnf

--- a/openssl.dns.default.cnf
+++ b/openssl.dns.default.cnf
@@ -1,7 +1,5 @@
-# This file is part of the openssl.cnf
-
 [ alt_names ]
 
 DNS.1 = localhost
-DNS.2 = test.localhost
-DNS.3 = *.test.localhost
+# DNS.2 = test.localhost
+# DNS.3 = *.test.localhost


### PR DESCRIPTION
Resolves #12 

Create final config file from intermediates:
```sh
cat ./openssl.base.cnf ./openssl.dns.cnf > ./output/openssl.cnf
```