### PR TITLE
Fix CentOS distributive

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Terminal output:
 
 ![!pric output](https://user-images.githubusercontent.com/1849174/67256373-5419fa00-f48f-11e9-884c-2a3cbe97bd73.png)
 
+### Tested on
+
+- Ubuntu
+- CentOS
+- macOS
+
 ### Import Certificate Authority to browser
 
 #### Firefox

--- a/pric.sh
+++ b/pric.sh
@@ -90,14 +90,14 @@ fi
 printf "\n# Updating operating system CA registry\n"
 case $OPERATING_SYSTEM in
   Linux*)
-    if [ $(command -v update-ca-certificates) ]; then
+    if [ "$(command -v update-ca-certificates)" ]; then
       (set -x; sudo update-ca-certificates)
-    elif [ $(command -v update-ca-trust) ]; then
+    elif [ "$(command -v update-ca-trust)" ]; then
       (set -x; sudo update-ca-trust)
     else
       LINUX_DISTRIBUTIVE=$(head -1 /etc/os-release | sed -e "s/NAME=//g" | sed -e "s/\"//g" | sed -e "s/ /+/g")
-      printf "\nUnsupported Linux Distributive: ${LINUX_DISTRIBUTIVE}"
-      printf "\nCreate an issue on GitHub https://github.com/pric/pric/issues/new?title=Linux+distributive+${LINUX_DISTRIBUTIVE}+not+supported\n"
+      printf "\nUnsupported Linux Distributive: %s" "${LINUX_DISTRIBUTIVE}"
+      printf "\nCreate an issue on GitHub https://github.com/pric/pric/issues/new?title=Linux+distributive+%s+not+supported\n" "${LINUX_DISTRIBUTIVE}"
       exit
     fi
     ;;
@@ -105,8 +105,8 @@ case $OPERATING_SYSTEM in
     (set -x; sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ${OUTPUT_CA_CERTIFICATE})
     ;;
   *)
-    printf "\nUnsupported OS: ${OPERATING_SYSTEM}"
-    printf "\nCreate an issue on GitHub https://github.com/pric/pric/issues/new?title=OS+${OPERATING_SYSTEM}+not+supported\n"
+    printf "\nUnsupported OS: %s" "${OPERATING_SYSTEM}"
+    printf "\nCreate an issue on GitHub https://github.com/pric/pric/issues/new?title=OS+%s+not+supported\n" "${OPERATING_SYSTEM}"
     exit
 esac
 

--- a/pric.sh
+++ b/pric.sh
@@ -16,7 +16,7 @@ OUTPUT_SERVER_CERTIFICATE="${OUTPUT_PATH}/localhost.crt"
 OUTPUT_SERVER_CERTIFICATE_SIGNING_REQUEST="${OUTPUT_PATH}/localhost.csr"
 OUTPUT_OPENSSL_CONFIG="${OUTPUT_PATH}/openssl.cnf"
 CERTIFICATE_CHAIN="${HOME}/localhost-certificate.pem"
-OPERATION_SYSTEM=$(uname -s)
+OPERATING_SYSTEM=$(uname -s)
 
 printf "!pric has been started\n"
 
@@ -88,16 +88,25 @@ fi
 
 ## Update operating system CA registry
 printf "\n# Updating operating system CA registry\n"
-case $OPERATION_SYSTEM in
+case $OPERATING_SYSTEM in
   Linux*)
-    (set -x; sudo update-ca-certificates)
+    if [ $(command -v update-ca-certificates) ]; then
+      (set -x; sudo update-ca-certificates)
+    elif [ $(command -v update-ca-trust) ]; then
+      (set -x; sudo update-ca-trust)
+    else
+      LINUX_DISTRIBUTIVE=$(head -1 /etc/os-release | sed -e "s/NAME=//g" | sed -e "s/\"//g" | sed -e "s/ /+/g")
+      printf "\nUnsupported Linux Distributive: ${LINUX_DISTRIBUTIVE}"
+      printf "\nCreate an issue on GitHub https://github.com/pric/pric/issues/new?title=Linux+distributive+${LINUX_DISTRIBUTIVE}+not+supported\n"
+      exit
+    fi
     ;;
   Darwin*)
     (set -x; sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ${OUTPUT_CA_CERTIFICATE})
     ;;
   *)
-    printf "\nUnsupported OS: ${OPERATION_SYSTEM}"
-    printf "\nCreate an issue on GitHub https://github.com/pric/pric/issues/new?title=OS+${OPERATION_SYSTEM}+not+supported\n"
+    printf "\nUnsupported OS: ${OPERATING_SYSTEM}"
+    printf "\nCreate an issue on GitHub https://github.com/pric/pric/issues/new?title=OS+${OPERATING_SYSTEM}+not+supported\n"
     exit
 esac
 


### PR DESCRIPTION
CentOS doesn't have `update-ca-certificates`, then `update-ca-trust` should be used instead.